### PR TITLE
Validate the 0 aggregator launch config

### DIFF
--- a/src/sosd.c
+++ b/src/sosd.c
@@ -229,6 +229,18 @@ int main(int argc, char *argv[])  {
         exit(EXIT_FAILURE);
     }
 
+    // Do some quick validation - if the user requested 0 aggregators, and this
+    // instance was launched as a listener, then silently change its role to
+    // aggregator.  All listeners will do the same.
+    if (SOSD.daemon.listener_count > 0 &&
+        SOSD.daemon.aggregator_count == 0) {
+        // swap the counts
+        SOSD.daemon.aggregator_count = SOSD.daemon.listener_count;
+        SOSD.daemon.listener_count = 0;
+        // change the role
+        my_role = SOS_ROLE_AGGREGATOR;
+    }
+
     // Done with param processing... fire things up.
 
     memset(&SOSD.daemon.pid_str, '\0', 256);


### PR DESCRIPTION
When a user launches SOS with N listeners and 0 aggregators, assume
that the user doesn't want to do any aggregation, but internally
and silently change the listener's role to aggregator, and swap
the counts.